### PR TITLE
Templating and a "Zettelkasten" (or "literary notes") mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Updated: {{ updated }}
 ![]( {{ cover_image_url }})
 
 # About
-Title: {{ title }}
+Title: [[{{ title }}]]
 Authors: {{ authorStr }}
 Category: #{{ category }}
 {%- if tags %}
@@ -130,12 +130,16 @@ Tags: {{ tags }}
 {%- endif %}
 Number of Highlights: =={{ num_highlights }}==
 Readwise URL: {{ highlights_url }}
+{%- if source_url %}
 Source URL: {{ source_url }}
+{%- endif %}
 Date: [[{{ updated }}]]
 Last Highlighted: *{{ last_highlight_at }}*
+
 ---
 
-# Highlights 
+# Highlights
+
 ```
 
 ### Highlights
@@ -153,7 +157,7 @@ The highlight template exposes the following variables:
 #### Default highlight template
 
 ```markdown+nunjucks
-{{ text }} %% highlight_id: {{ id }} %%
+{{ text }} {%- if category == 'books' %}([{{ location }}]({{ locationUrl }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
 Note: {{ note }}
 {%- endif %}

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The highlight template exposes the following variables:
 #### Default highlight template
 
 ```markdown+nunjucks
-{{ text }} {%- if category == 'books' %}([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }}
+{{ text }}{%- if category == 'books' %} ([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }}
 {%- if note %}
 
 Note: {{ note }}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The highlight template exposes the following variables:
 - ```text```: The highlighted text
 - ```note```: Your nore
 - ```location```: The location
-- ```url```: The url of the location
+- ```location_url```: The url of the location
 - ```color```: The color
 - ```highlighted_at```: Date highlighted (empty if none)
 - ```tags```: A formatted string of tags
@@ -159,8 +159,9 @@ The highlight template exposes the following variables:
 #### Default highlight template
 
 ```markdown+nunjucks
-{{ text }} {%- if category == 'books' %}([{{ location }}]({{ url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
+{{ text }} {%- if category == 'books' %}([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }}
 {%- if note %}
+
 Note: {{ note }}
 {%- endif %}
 ```

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Source URL: {{ source_url }}
 Date: [[{{ updated }}]]
 Last Highlighted: *{{ last_highlight_at }}*
 ---
+
+# Highlights 
 ```
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -55,6 +55,85 @@ As a reference for performance, syncing my library of 5,067 Highlights across 92
 - In Obsidian, go to Settings, scroll down to Community Plug-ins, and activate it.
   - If it refuses to activate with an error message, open the developer console (with Ctrl-Shift-I) and check for error messages.
 
-## Future possible feature ideas
-- Custom Template engine support
-  - Would allow for custom headers/footers
+## Sync highlights with notes only
+A lot of the value of Readwise highlights lies in the notes associated with them. E.g. if you are building a Zettelkasten and want to work with literature notes, you typically only want highlights with notes in your Zettelkasten -- and not every highlight. 
+
+The option "Only sync highlights with notes" will do exactly that: it will only sync highlights with notes. If an item in your library has only highlights without notes, it will not be synced.
+## Templating
+The plugin allows for simple templating. Similarly to Readwise's templating, it allows to define - a header template,
+- a highlight template, and
+- a template for frontmatter
+
+The frontmatter template can be turned on and off. If you want to revert to the default template, you can just empty the template completely and the plugin will restore the default.
+
+### Header and frontmatter template
+The template exposes the following variables (they can be used for both the header and frontmatter):
+
+- ```id```: Document id,
+- ```title```: Sanitized title,
+- ```author```: Author (formatted),
+- ```category```: Document category,
+- ```num_highlights```: Number of highlights,
+- ```updated```: Date of last update,
+- ```cover_image_url```: Cover image,
+- ```highlights_url```: Readwise URL,
+- ```highlights```: Highlights,
+- ```last_highlight_at```: Date of last highlight,
+- ```source_url```: Source URL,
+- ```tags```: Document tags
+
+#### Default frontmatter template
+```
+---
+id: {{ id }}
+updated: {{ updated }}
+title: {{ title }}
+author: {{ author }}
+---
+```
+
+#### Default header template
+```
+%%
+ID: {{ id }}
+Updated: {{ updated }}
+%%
+
+![]( {{ cover_image_url }})
+
+# About
+Title: {{ title }}
+Authors: {{ authorStr }}
+Category: # {{ category }}
+{%- if tags %}
+Tags: {{ tags }}
+{%- endif %}
+Number of Highlights: =={{ num_highlights }}==
+Readwise URL: {{ highlights_url }}
+Source URL: {{ source_url }}
+Date: [[{{ updated }}]]
+Last Highlighted: *{{ last_highlight_at }}*
+---
+```
+
+### Highlights
+
+The highlight template exposes the following variables:
+
+- ```id```: The id of the highlight
+- ```text```: The highlighted text
+- ```note```: Your nore
+- ```location```: The location
+- ```color```: The color
+- ```highlighted_at```: Date highlighted (empty if none)
+- ```tags```: A formatted string of tags
+#### Default highlight template
+```
+{{ text }} %% highlight_id: {{ id }} %%
+{%- if note %}
+Note: {{ note }}
+{%- endif %}
+```
+### Limitations
+- The templating is based on the [`nunjucks`](https://mozilla.github.io/nunjucks/templating.html) templating library and thus shares its limitations;
+- Certain strings (e.g. date, tags, authors) are currently preformatted

--- a/README.md
+++ b/README.md
@@ -150,14 +150,16 @@ The highlight template exposes the following variables:
 - ```text```: The highlighted text
 - ```note```: Your nore
 - ```location```: The location
+- ```url```: The url of the location
 - ```color```: The color
 - ```highlighted_at```: Date highlighted (empty if none)
 - ```tags```: A formatted string of tags
+- ```category``: Categroy of the source item (book, article, etc.)
 
 #### Default highlight template
 
 ```markdown+nunjucks
-{{ text }} {%- if category == 'books' %}([{{ location }}]({{ locationUrl }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
+{{ text }} {%- if category == 'books' %}([{{ location }}]({{ url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
 Note: {{ note }}
 {%- endif %}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Readwise Mirror Plugin
+
 **Readwise Mirror** is an unoffical open source plugin for the powerful note-taking and knowledge-base application [Obsidian](http://obsidian.md/). This plugin allows a user to "mirror" their entire Readwise library by automatically downloading all highlights/notes and syncing changes directly into an Obsidian vault.
 
 ![example.gif](https://raw.githubusercontent.com/jsonMartin/readwise-mirror/master/example.gif)
@@ -8,6 +9,7 @@ The format of the output is similar to the Markdown export available directly fr
 The first time this plugin is ran, it will do a full sync downloading all content from Readwise. Every subsequent sync will only check for sources with new changes made after the last sync attempt; if any are found, it will automatically regenerate the note with the most current data.
 
 ## Features
+
 - Supports custom folder for Readwise Library content (default is `Readwise`)
 - Subfolders for content type (such as `Books`, `Articles`, etc)
 - Full one-way sync ensuring highlights are always current
@@ -18,36 +20,45 @@ The first time this plugin is ran, it will do a full sync downloading all conten
 - Supports tags, both within highlights as well as sources (books, articles, etc)
 
 ## Usage
+
 After installing, visit the plugin configuration page to enter the Readwise Access Token, which can be found here: [https://readwise.io/access_token](https://readwise.io/access_token)
 
 Then run any of the below commands or click the Readwise toolbar to sync for the first time.
+
 ## Commands
+
 - `Sync new highlights`: Download all new highlights since previous update
 - `Test Readwise API key`: Ensure the Access Token works
 - `Delete Readwise library`: Remove the Readwise library file folder from vault
 - `Download entire Readwise library (force)`: Forces a full download of all content from Readwise
 
 ## How does this work?
+
 ### One-way mirror sync vs append-based sync
+
 Any changes made to content in Readwise will be automatically updated during the next sync. **It's important to note that this is a *read only/one way sync*, meaning that any new highlights detected from Readwise will cause the note file to automatically regenerate with the new content**. This was a deliberate design decision to ensure that Readwise is the ultimate source of truth for data; any changes to currently existing highlights in Readwise are always reflected rather than getting out of sync. While another possible solution is to append new highlights to existing content notes instead, it is not feasible to modify existing highlights; this is how Readwise's integration with other services such as Notion & Roam work:
-> If I edit or format an existing highlight in Readwise, or make a new note or tag to an existing highlight, will that change be updated in Notion? <br /><br />
+> If I edit or format an existing highlight in Readwise, or make a new note or tag to an existing highlight, will that change be updated in Notion?
 > Not at the moment. Any edits, formatting, notes, or tags you had in Readwise before your first sync with Notion will appear in Notion, but new updates to existing highlights will not be reflected in already synced highlights.
 
 ### The `obsidian-readwise` plugin for append-based syncing
+
 In addition to this plugin, there is also another Readwise community plugin for Obsidian named [obsidian-readwise](https://github.com/renehernandez/obsidian-readwise), which can be found at: [https://github.com/renehernandez/obsidian-readwise](https://github.com/renehernandez/obsidian-readwise). Both plugins exist for different use cases, so please read below to determine which best suits your needs.
 
 **Because of the way the mirror sync works in this plugin, users lose the ability to modify their notes as the plugin is responsible for managing all note files in the Readwise library.** If a user needs full control over their library or the ability to modify notes and highlights directly in Obsidian, [obsidian-readwise](https://github.com/renehernandez/obsidian-readwise) would be the better choice.
 
 #### **TL;DR**
+
 - Download [obsidian-readwise](https://github.com/renehernandez/obsidian-readwise) to import new highlights to your library with full control over the ability to modify and format your notes
 - Download this plugin if you want to mirror your entire Readwise Library into Obsidian and sync modifications to previous highlights
 
 ## Performance
+
 If the update is so large that a Readwise API limit is reached, this plugin has a rate limiting throttling solution in place to continue automatically continue downloading the entire library as soon as the limit expires.
 
 As a reference for performance, syncing my library of 5,067 Highlights across 92 books and 9 articles took approximately 20 seconds.
 
 ## Manual Installation
+
 - Browse to [releases](https://github.com/jsonMartin/readwise-mirror/releases)
 - Download `main.js` and `manifest.json` of the latest release
 - Create a `readwise-mirror` subdirectory in your Obsidian plug-in directory (in `.obsidian/plugins` in your vault)
@@ -56,11 +67,14 @@ As a reference for performance, syncing my library of 5,067 Highlights across 92
   - If it refuses to activate with an error message, open the developer console (with Ctrl-Shift-I) and check for error messages.
 
 ## Sync highlights with notes only
-A lot of the value of Readwise highlights lies in the notes associated with them. E.g. if you are building a Zettelkasten and want to work with literature notes, you typically only want highlights with notes in your Zettelkasten -- and not every highlight. 
+
+A lot of the value of Readwise highlights lies in the notes associated with them. E.g. if you are building a Zettelkasten and want to work with literature notes, you typically only want highlights with notes in your Zettelkasten -- and not every highlight.
 
 The option "Only sync highlights with notes" will do exactly that: it will only sync highlights with notes. If an item in your library has only highlights without notes, it will not be synced.
+
 ## Templating
-The plugin allows for simple templating. Similarly to Readwise's templating, it allows to define 
+
+The plugin allows for simple templating. Similarly to Readwise's templating, it allows to define
 
 - a header template,
 - a highlight template, and
@@ -69,6 +83,7 @@ The plugin allows for simple templating. Similarly to Readwise's templating, it 
 The frontmatter template can be turned on and off. If you want to revert to the default template, you can just empty the template completely and the plugin will restore the default.
 
 ### Header and frontmatter template
+
 The template exposes the following variables (they can be used for both the header and frontmatter):
 
 - ```id```: Document id,
@@ -85,7 +100,8 @@ The template exposes the following variables (they can be used for both the head
 - ```tags```: Document tags
 
 #### Default frontmatter template
-```
+
+```markdown+nunjucks
 ---
 id: {{ id }}
 updated: {{ updated }}
@@ -95,7 +111,8 @@ author: {{ author }}
 ```
 
 #### Default header template
-```
+
+```markdown+nunjucks
 %%
 ID: {{ id }}
 Updated: {{ updated }}
@@ -129,13 +146,18 @@ The highlight template exposes the following variables:
 - ```color```: The color
 - ```highlighted_at```: Date highlighted (empty if none)
 - ```tags```: A formatted string of tags
+
 #### Default highlight template
-```
+
+```markdown+nunjucks
 {{ text }} %% highlight_id: {{ id }} %%
 {%- if note %}
 Note: {{ note }}
 {%- endif %}
 ```
+
 ### Limitations
+
 - The templating is based on the [`nunjucks`](https://mozilla.github.io/nunjucks/templating.html) templating library and thus shares its limitations;
 - Certain strings (e.g. date, tags, authors) are currently preformatted
+- If you have frontmatter and items with `@` in the title or author's name (typically this happens with highlights imported from Twitter), the frontmatter will be invalid.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ A lot of the value of Readwise highlights lies in the notes associated with them
 
 The option "Only sync highlights with notes" will do exactly that: it will only sync highlights with notes. If an item in your library has only highlights without notes, it will not be synced.
 ## Templating
-The plugin allows for simple templating. Similarly to Readwise's templating, it allows to define - a header template,
+The plugin allows for simple templating. Similarly to Readwise's templating, it allows to define 
+
+- a header template,
 - a highlight template, and
 - a template for frontmatter
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ The template exposes the following variables (they can be used for both the head
 
 - ```id```: Document id,
 - ```title```: Sanitized title,
-- ```author```: Author (formatted),
+- ```author```: Author (raw),
+- ```authorStr```: Author (formatted, as Wiki Links ```[[Author Name]]```),
 - ```category```: Document category,
 - ```num_highlights```: Number of highlights,
 - ```updated```: Date of last update,

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Updated: {{ updated }}
 # About
 Title: {{ title }}
 Authors: {{ authorStr }}
-Category: # {{ category }}
+Category: #{{ category }}
 {%- if tags %}
 Tags: {{ tags }}
 {%- endif %}

--- a/main.ts
+++ b/main.ts
@@ -48,7 +48,7 @@ Updated: {{ updated }}
 # About
 Title: {{ title }}
 Authors: {{ authorStr }}
-Category: # {{ category }}
+Category: #{{ category }}
 {%- if tags %}
 Tags: {{ tags }}
 {%- endif %}

--- a/main.ts
+++ b/main.ts
@@ -65,8 +65,9 @@ Last Highlighted: *{{ last_highlight_at }}*
 # Highlights 
 
 `,
-  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
+  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
+
 Note: {{ note }}
 {%- endif %}
 `,
@@ -89,7 +90,6 @@ export default class ReadwiseMirror extends Plugin {
     const { id, text, note, location, color, url, tags, highlighted_at } = highlight;
     
     const locationUrl = `https://readwise.io/to_kindle?action=open&asin=${book['asin']}&location=${location}`;
-    const locationBlock = location !== null ? `([${location}](${locationUrl}))` : '';
 
     const formattedTags = tags.filter((tag) => tag.name !== color);
     const formattedTagStr = this.formatTags(formattedTags);
@@ -100,7 +100,7 @@ export default class ReadwiseMirror extends Plugin {
       text: text,
       note: note,
       location: location,
-      url: url,
+      location_url: locationUrl,
       color: color,
       highlighted_at: highlighted_at ? this.formatDate(highlighted_at) : '',
       tags: formattedTagStr,

--- a/main.ts
+++ b/main.ts
@@ -65,7 +65,7 @@ Last Highlighted: *{{ last_highlight_at }}*
 # Highlights 
 
 `,
-  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ locationUrl }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
+  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
 Note: {{ note }}
 {%- endif %}
@@ -86,8 +86,8 @@ export default class ReadwiseMirror extends Plugin {
   }
 
   private formatHighlight(highlight: Highlight, book: Book) {
-    const { id, text, note, location, color, tags, highlighted_at } = highlight;
-
+    const { id, text, note, location, color, url, tags, highlighted_at } = highlight;
+    
     const locationUrl = `https://readwise.io/to_kindle?action=open&asin=${book['asin']}&location=${location}`;
     const locationBlock = location !== null ? `([${location}](${locationUrl}))` : '';
 
@@ -95,13 +95,17 @@ export default class ReadwiseMirror extends Plugin {
     const formattedTagStr = this.formatTags(formattedTags);
 
     return this.highlightTemplate.render({
+      // Highlight fields
       id: id,
       text: text,
       note: note,
       location: location,
+      url: url,
       color: color,
       highlighted_at: highlighted_at ? this.formatDate(highlighted_at) : '',
       tags: formattedTagStr,
+      // Book fields
+      category: book.category,
     });
   }
 

--- a/main.ts
+++ b/main.ts
@@ -58,6 +58,8 @@ Source URL: {{ source_url }}
 Date: [[{{ updated }}]]
 Last Highlighted: *{{ last_highlight_at }}*
 ---
+
+# Highlights 
 `,
   highlightTemplate: `{{ text }} %% highlight_id: {{ id }} %%
 {%- if note %}
@@ -218,10 +220,7 @@ export default class ReadwiseMirror extends Plugin {
 
         const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';
         const headerContents = this.headerTemplate.render(metadata);
-        const contents = `${frontMatterContents}${headerContents}
-
-# Highlights 
-${formattedHighlights}`;
+        const contents = `${frontMatterContents}${headerContents}${formattedHighlights}`;
 
         let path = `${this.settings.baseFolderName}/${
           category.charAt(0).toUpperCase() + category.slice(1)

--- a/main.ts
+++ b/main.ts
@@ -65,7 +65,7 @@ Last Highlighted: *{{ last_highlight_at }}*
 # Highlights 
 
 `,
-  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
+  highlightTemplate: `{{ text }}{%- if category == 'books' %} ([{{ location }}]({{ location_url }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
 
 Note: {{ note }}

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
 import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
 import Notify from 'notify';
 import spacetime from 'spacetime';
+import { Environment, Template, ConfigureOptions } from 'nunjucks';
 
 import { ReadwiseApi, Library, Highlight, Book, Tag } from 'readwiseApi';
 
@@ -10,8 +11,13 @@ interface PluginSettings {
   lastUpdated: string | null;
   autoSync: boolean;
   highlightSortOldestToNewest: boolean;
+  syncNotesOnly: boolean;
   logFile: boolean;
   logFileName: string;
+  frontMatter: boolean;
+  frontMatterTemplate: string;
+  headerTemplate: string;
+  highlightTemplate: string;
 }
 
 const DEFAULT_SETTINGS: PluginSettings = {
@@ -20,34 +26,82 @@ const DEFAULT_SETTINGS: PluginSettings = {
   lastUpdated: null,
   autoSync: true,
   highlightSortOldestToNewest: true,
+  syncNotesOnly: false,
   logFile: true,
   logFileName: 'Sync.md',
+  frontMatter: false,
+  frontMatterTemplate: `---
+id: {{ id }}
+updated: {{ updated }}
+title: {{ title }}
+author: {{ author }}
+---
+`,
+  headerTemplate: `
+%%
+ID: {{ id }}
+Updated: {{ updated }}
+%%
+
+![]( {{ cover_image_url }})
+
+# About
+Title: {{ title }}
+Authors: {{ authorStr }}
+Category: # {{ category }}
+{%- if tags %}
+Tags: {{ tags }}
+{%- endif %}
+Number of Highlights: =={{ num_highlights }}==
+Readwise URL: {{ highlights_url }}
+Source URL: {{ source_url }}
+Date: [[{{ updated }}]]
+Last Highlighted: *{{ last_highlight_at }}*
+---
+`,
+  highlightTemplate: `{{ text }} %% highlight_id: {{ id }} %%
+{%- if note %}
+Note: {{ note }}
+{%- endif %}
+`,
 };
 
 export default class ReadwiseMirror extends Plugin {
   settings: PluginSettings;
   readwiseApi: ReadwiseApi;
   notify: Notify;
+  env: Environment;
+  frontMatterTemplate: Template;
+  headerTemplate: Template;
+  highlightTemplate: Template;
 
   private formatTags(tags: Tag[]) {
     return tags.map((tag) => `#${tag.name}`).join(', ');
   }
 
   private formatHighlight(highlight: Highlight, book: Book) {
-    const { id, text, note, location, color, tags } = highlight;
+    const { id, text, note, location, color, tags, highlighted_at } = highlight;
+
     const locationUrl = `https://readwise.io/to_kindle?action=open&asin=${book['asin']}&location=${location}`;
     const locationBlock = location !== null ? `([${location}](${locationUrl}))` : '';
 
     const formattedTags = tags.filter((tag) => tag.name !== color);
     const formattedTagStr = this.formatTags(formattedTags);
 
-    return `
-${text} ${book.category === 'books' ? locationBlock : ''}${color ? ` %% Color: ${color} %%` : ''} ^${id}${
-      note ? `\n\n**Note: ${note}**` : ``
-    }${formattedTagStr.length >= 1 ? `\n\n**Tags: ${formattedTagStr}**` : ``}
+    return this.highlightTemplate.render({
+      id: id,
+      text: text,
+      note: note,
+      location: location,
+      color: color,
+      highlighted_at: highlighted_at ? this.formatDate(highlighted_at) : '',
+      tags: formattedTagStr,
+    });
+  }
 
----
-`;
+  private filterHighlight(highlight: Highlight) {
+    if (this.settings.syncNotesOnly && !highlight.note) return false;
+    else return true;
   }
 
   private formatDate(dateStr: string) {
@@ -123,55 +177,69 @@ ${text} ${book.category === 'books' ? locationBlock : ''}${color ? ` %% Color: $
       } = book;
       const sanitizedTitle = `${title.replace(':', '-').replace(/[<>"'\/\\|?*]+/g, '')}`;
 
-      const formattedHighlights = (this.settings.highlightSortOldestToNewest ? highlights.reverse() : highlights)
-        .map((highlight: Highlight) => this.formatHighlight(highlight, book))
-        .join('')
-        .replace(/---\n$/g, '');
+      const filteredHighlights = highlights.filter((highlight: Highlight) => this.filterHighlight(highlight));
 
-      const authors = author ? author.split(/and |,/) : [];
+      if (filteredHighlights.length == 0) {
+        console.log(`Readwise: No highlights found for '${sanitizedTitle}'`);
+      } else {
+        const formattedHighlights = (
+          this.settings.highlightSortOldestToNewest ? filteredHighlights.reverse() : filteredHighlights
+        )
+          .map((highlight: Highlight) => this.formatHighlight(highlight, book))
+          .join('\n');
 
-      let authorStr =
-        authors[0] && authors?.length > 1
-          ? authors
-              .filter((authorName: string) => authorName.trim() != '')
-              .map((authorName: string) => `[[${authorName.trim()}]]`)
-              .join(', ')
-          : author
-          ? `[[${author}]]`
-          : ``;
+        const authors = author ? author.split(/and |,/) : [];
 
-      const contents = `%%
-ID: ${id}
-Updated: ${this.formatDate(updated)}
-%%
-![](${cover_image_url.replace('SL200', 'SL500').replace('SY160', 'SY500')})
+        let authorStr =
+          authors[0] && authors?.length > 1
+            ? authors
+                .filter((authorName: string) => authorName.trim() != '')
+                .map((authorName: string) => `[[${authorName.trim()}]]`)
+                .join(', ')
+            : author
+            ? `[[${author}]]`
+            : ``;
 
-# About
-Title: [[${sanitizedTitle}]]
-${authors.length > 1 ? 'Authors' : 'Author'}: ${authorStr}
-Category: #${category}${tags.length > 1 ? '\nTags: ' + this.formatTags(tags) : ''}
-Number of Highlights: ==${num_highlights}==
-Last Highlighted: *${last_highlight_at ? this.formatDate(last_highlight_at) : 'Never'}*
-Readwise URL: ${highlights_url}${category === 'articles' ? `\nSource URL: ${source_url}\n` : ''}
+        const metadata = {
+          id: id,
+          title: sanitizedTitle,
+          author: author,
+          authorStr: authorStr,
+          category: category,
+          num_highlights: num_highlights,
+          updated: this.formatDate(updated),
+          cover_image_url: cover_image_url.replace('SL200', 'SL500').replace('SY160', 'SY500'),
+          highlights_url: highlights_url,
+          highlights: highlights,
+          last_highlight_at: last_highlight_at ? this.formatDate(last_highlight_at) : '',
+          source_url: source_url,
+          tags: this.formatTags(tags),
+        };
 
-# Highlights ${formattedHighlights}`;
+        const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';
+        const headerContents = this.headerTemplate.render(metadata);
+        const contents = `${frontMatterContents}${headerContents}
 
-      let path = `${this.settings.baseFolderName}/${
-        category.charAt(0).toUpperCase() + category.slice(1)
-      }/${sanitizedTitle}.md`;
+# Highlights 
+${formattedHighlights}`;
 
-      const abstractFile = vault.getAbstractFileByPath(path);
+        let path = `${this.settings.baseFolderName}/${
+          category.charAt(0).toUpperCase() + category.slice(1)
+        }/${sanitizedTitle}.md`;
 
-      // Delete old instance of file
-      if (abstractFile) {
-        try {
-          await vault.delete(abstractFile);
-        } catch (err) {
-          console.error(`Readwise: Attempted to delete file ${path} but no file was found`, err);
+        const abstractFile = vault.getAbstractFileByPath(path);
+
+        // Delete old instance of file
+        if (abstractFile) {
+          try {
+            await vault.delete(abstractFile);
+          } catch (err) {
+            console.error(`Readwise: Attempted to delete file ${path} but no file was found`, err);
+          }
         }
-      }
 
-      vault.create(path, contents);
+        vault.create(path, contents);
+      }
     }
   }
 
@@ -256,6 +324,12 @@ Readwise URL: ${highlights_url}${category === 'articles' ? `\nSource URL: ${sour
     await this.loadSettings();
 
     const statusBarItem = this.addStatusBarItem();
+
+    // Setup templating
+    this.env = new Environment(null, { autoescape: false } as ConfigureOptions);
+    this.frontMatterTemplate = new Template(this.settings.frontMatterTemplate, this.env, null, true);
+    this.headerTemplate = new Template(this.settings.headerTemplate, this.env, null, true);
+    this.highlightTemplate = new Template(this.settings.highlightTemplate, this.env, null, true);
 
     this.notify = new Notify(statusBarItem);
 
@@ -394,6 +468,18 @@ class ReadwiseMirrorSettingTab extends PluginSettingTab {
       );
 
     new Setting(containerEl)
+      .setName('Only sync highlights with notes')
+      .setDesc(
+        'If checked, highlights will only be synced if they have a note. This makes it easier to use these notes for Zettelkasten.'
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.syncNotesOnly).onChange(async (value) => {
+          this.plugin.settings.syncNotesOnly = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
       .setName('Sync Log')
       .setDesc('Save sync log to file in Library')
       .addToggle((toggle) =>
@@ -415,6 +501,71 @@ class ReadwiseMirrorSettingTab extends PluginSettingTab {
             this.plugin.settings.logFileName = value;
             await this.plugin.saveSettings();
           })
+      );
+
+    new Setting(containerEl)
+      .setName('Header Template')
+      .setDesc('')
+      .addTextArea((text) =>
+        text.setValue(this.plugin.settings.headerTemplate).onChange(async (value) => {
+          if (!value) {
+            this.plugin.settings.headerTemplate = DEFAULT_SETTINGS.headerTemplate;
+          } else {
+            this.plugin.settings.headerTemplate = value;
+          }
+          this.plugin.headerTemplate = new Template(this.plugin.settings.headerTemplate, this.plugin.env, null, true);
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName('Frontmatter')
+      .setDesc('Add frontmatter (defined with the following Template)')
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.frontMatter).onChange(async (value) => {
+          this.plugin.settings.frontMatter = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName('Frontmatter Template')
+      .setDesc('')
+      .addTextArea((text) =>
+        text.setValue(this.plugin.settings.frontMatterTemplate).onChange(async (value) => {
+          if (!value) {
+            this.plugin.settings.frontMatterTemplate = DEFAULT_SETTINGS.frontMatterTemplate;
+          } else {
+            this.plugin.settings.frontMatterTemplate = value;
+          }
+          this.plugin.frontMatterTemplate = new Template(
+            this.plugin.settings.frontMatterTemplate,
+            this.plugin.env,
+            null,
+            true
+          );
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName('Highlight Template')
+      .setDesc('')
+      .addTextArea((text) =>
+        text.setValue(this.plugin.settings.highlightTemplate).onChange(async (value) => {
+          if (!value) {
+            this.plugin.settings.highlightTemplate = DEFAULT_SETTINGS.highlightTemplate;
+          } else {
+            this.plugin.settings.highlightTemplate = value;
+          }
+          this.plugin.highlightTemplate = new Template(
+            this.plugin.settings.highlightTemplate,
+            this.plugin.env,
+            null,
+            true
+          );
+          await this.plugin.saveSettings();
+        })
       );
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -46,7 +46,7 @@ Updated: {{ updated }}
 ![]( {{ cover_image_url }})
 
 # About
-Title: {{ title }}
+Title: [[{{ title }}]]
 Authors: {{ authorStr }}
 Category: #{{ category }}
 {%- if tags %}
@@ -54,14 +54,18 @@ Tags: {{ tags }}
 {%- endif %}
 Number of Highlights: =={{ num_highlights }}==
 Readwise URL: {{ highlights_url }}
+{%- if source_url %}
 Source URL: {{ source_url }}
+{%- endif %}
 Date: [[{{ updated }}]]
 Last Highlighted: *{{ last_highlight_at }}*
+
 ---
 
 # Highlights 
+
 `,
-  highlightTemplate: `{{ text }} %% highlight_id: {{ id }} %%
+  highlightTemplate: `{{ text }} {%- if category == 'books' %}([{{ location }}]({{ locationUrl }})){%- endif %}{%- if color %}%% Color: {{ color }} %%{%- endif %} ^{{ id }} %%
 {%- if note %}
 Note: {{ note }}
 {%- endif %}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "typescript": "^4.2.4"
   },
   "dependencies": {
+    "@types/nunjucks": "^3.2.0",
+    "nunjucks": "^3.2.3",
     "spacetime": "^6.16.0"
   }
 }


### PR DESCRIPTION
This patch implements two features (I missed the moment to clearly separate them, I hope it's still acceptable):

- Simple templating (possibly implementing #11); and a
- *Zettelkasten* mode

## Templating

The plugin allows for simple templating. Similarly to Readwise's export to Obsidian, it allows defining

- a header template,
- a highlight template, and
- a template for front matter

The front matter template can be turned on and off. If you want to revert to the default template, you can just empty the template completely and the plugin will restore the default.

The templating engine I use is `nunjucks` and the `README.md` contains the default templates and the variables that can be used in the templates.

## Sync highlights with notes only

A lot of the value of Readwise highlights lies in the notes associated with them, written by you, particularly if you are building a *Zettelkasten*. If you want to use Obsidian with Readwise but want to work with literature notes, you typically only want highlights with notes in your *Zettelkasten* -- and not every highlight.

The option "Only sync highlights with notes" will do exactly that: it will only sync highlights with notes. If an item in your library has only highlights without notes, it will not be synced.
