### PR TITLE
Sort Highlights By Location and Filter Discarded Highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.3.0 (2022-12-10)
+### Added
+- Sort Highlights by Location (instead of date highlighted).
+  - This will display highlights in order of page location, from least to greatest.
+  - Combine with Sort Highlights from Oldest to Newest to reverse the sort order.
+- Hide Discarded Highlights.
+  - With this option enabled, highlights that have been discarded in Readwise will not be displayed in the Obsidian library.
+
 ## 1.1.1 (2021-08-01)
 ### Added
 - Added Sync Log functionality. Creates a file (configurable, with a default filename of `Sync.md`) in the Readwise library root folder, which stores a time-based log listing when Readwise sources have synced new highlights

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "readwise-mirror",
   "name": "Readwise Mirror",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "minAppVersion": "0.11.0",
   "description": "Mirror your Readwise library directly to an Obsidian vault",
   "author": "jsonmartin",


### PR DESCRIPTION
- Sort Highlights by Location (instead of date highlighted)
  - This will display highlights in order of page location, from least to greatest.
  - Combine with Sort Highlights from Oldest to Newest to reverse the sort order.
  - Resolves #10 
- Hide Discarded Highlights
  - With this option enabled, highlights that have been discarded in Readwise will not be displayed in the Obsidian library.
  - Resolves #17 