### PR TITLE
feat: ✨ implement additional tag functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ Note: {{ note }}
 
 - The templating is based on the [`nunjucks`](https://mozilla.github.io/nunjucks/templating.html) templating library and thus shares its limitations;
 - Certain strings (e.g. date, tags, authors) are currently preformatted
-- If you have frontmatter and items with `@` in the title or author's name (typically this happens with highlights imported from Twitter), the frontmatter will be invalid.
+- If you have frontmatter and items with `@` in the title or author's name (typically this happens with highlights imported from Twitter), the frontmatter will be invalid. You can add quotes in your frontmatter template to try to work around these cases: `title: "{{ title }}" but any quotes already present in the title will break your frontmatter too.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ The template exposes the following variables (they can be used for both the head
 - ```highlights```: Highlights,
 - ```last_highlight_at```: Date of last highlight,
 - ```source_url```: Source URL,
-- ```tags```: Document tags
+- ```tags```: Document tags,
+- ```frontmatter_tags```: Document tags to be used in an array in frontmatter  (use `tags: [ {{ frontmatter_tags }}]` in your frontmatter template)
 
 #### Default frontmatter template
 

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The template exposes the following variables (they can be used for both the head
 - ```source_url```: Source URL,
 - ```tags```: Document tags,
 - ```highlight_tags```: Rolled-up list of highlight tags,
-- ```tags_nohash```: Document tags withough "#" to be used in an array in frontmatter (use `tags: [ {{ tags_nohash }}]` in your frontmatter template)
-- ```hl_tags_nohash```: List of all highlight tags to be used in an array in frontmatter (withouth "#",, similar to `tags_nohash`, but with single quotes "'" to avoid issues with tags that are valid in readwise but require special care when used in Obsidian frontmatter (e.g. tags using '@'))
+- ```tags_nohash```: Document tags withough "#",  but with single quotes "'" to avoid issues with tags that are valid in readwise but require special care when used in Obsidian frontmatter (e.g. tags using '@'). To be used in an array in frontmatter (use `tags: [ {{ tags_nohash }}]` in your frontmatter template)
+- ```hl_tags_nohash```: List of all highlight tags to be used in an array in frontmatter (withouth "#", similar to `tags_nohash`)
 
 #### Default frontmatter template
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ The template exposes the following variables (they can be used for both the head
 - ```last_highlight_at```: Date of last highlight,
 - ```source_url```: Source URL,
 - ```tags```: Document tags,
-- ```quoted_tags```: Document tags to be used in an array in frontmatter  (use `tags: [ {{ frontmatter_tags }}]` in your frontmatter template)
-- ```quoted_highlight_tags```: List of all highlight tags to be used in an array in frontmatter (similar to `quoted_tags`)
+- ```highlight_tags```: Rolled-up list of highlight tags,
+- ```tags_nohash```: Document tags withough "#" to be used in an array in frontmatter (use `tags: [ {{ tags_nohash }}]` in your frontmatter template)
+- ```hl_tags_nohash```: List of all highlight tags to be used in an array in frontmatter (withouth "#", similar to `tags_nohash`)
 
 #### Default frontmatter template
 
@@ -126,7 +127,7 @@ author: "{{ author }}"
 highlights: {{ num_highlights }}
 last_highlight_at: {{ last_highlight_at }}
 source: {{ source_url }}
-tags: [ {%- if quoted_tags %}{{ quoted_tags }},{%- endif %}{%- if quoted_highlight_tags %} {{ quoted_highlight_tags }}{%- endif %} ]
+tags: [ {%- if tags_nohash %}{{ tags_nohash }},{%- endif %}{%- if hl_tags_nohash %} {{ hl_tags_nohash }}{%- endif %} ]
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The template exposes the following variables (they can be used for both the head
 - ```last_highlight_at```: Date of last highlight,
 - ```source_url```: Source URL,
 - ```tags```: Document tags,
-- ```frontmatter_tags```: Document tags to be used in an array in frontmatter  (use `tags: [ {{ frontmatter_tags }}]` in your frontmatter template)
+- ```quoted_tags```: Document tags to be used in an array in frontmatter  (use `tags: [ {{ frontmatter_tags }}]` in your frontmatter template)
+- ```quoted_highlight_tags```: List of all highlight tags to be used in an array in frontmatter (similar to `quoted_tags`)
 
 #### Default frontmatter template
 
@@ -109,6 +110,23 @@ id: {{ id }}
 updated: {{ updated }}
 title: {{ title }}
 author: {{ author }}
+---
+```
+
+#### Example of a more complex frontmatter template
+
+The following would print both document and all highlight tags, rolled-up:
+
+```markdown+nunjucks
+---
+id: {{ id }}
+updated: {{ updated }}
+title: "{{ title }}"
+author: "{{ author }}"
+highlights: {{ num_highlights }}
+last_highlight_at: {{ last_highlight_at }}
+source: {{ source_url }}
+tags: [ {%- if quoted_tags %}{{ quoted_tags }},{%- endif %}{%- if quoted_highlight_tags %} {{ quoted_highlight_tags }}{%- endif %} ]
 ---
 ```
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The highlight template exposes the following variables:
 - ```color```: The color
 - ```highlighted_at```: Date highlighted (empty if none)
 - ```tags```: A formatted string of tags
-- ```category```: Categroy of the source item (book, article, etc.)
+- ```category```: Category of the source item (book, article, etc.)
 
 #### Default highlight template
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The template exposes the following variables (they can be used for both the head
 - ```tags```: Document tags,
 - ```highlight_tags```: Rolled-up list of highlight tags,
 - ```tags_nohash```: Document tags withough "#" to be used in an array in frontmatter (use `tags: [ {{ tags_nohash }}]` in your frontmatter template)
-- ```hl_tags_nohash```: List of all highlight tags to be used in an array in frontmatter (withouth "#", similar to `tags_nohash`)
+- ```hl_tags_nohash```: List of all highlight tags to be used in an array in frontmatter (withouth "#",, similar to `tags_nohash`, but with single quotes "'" to avoid issues with tags that are valid in readwise but require special care when used in Obsidian frontmatter (e.g. tags using '@'))
 
 #### Default frontmatter template
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The highlight template exposes the following variables:
 - ```color```: The color
 - ```highlighted_at```: Date highlighted (empty if none)
 - ```tags```: A formatted string of tags
-- ```category``: Categroy of the source item (book, article, etc.)
+- ```category```: Categroy of the source item (book, article, etc.)
 
 #### Default highlight template
 

--- a/main.ts
+++ b/main.ts
@@ -161,6 +161,17 @@ export default class ReadwiseMirror extends Plugin {
     return sortedHighlights;
   };
 
+  private getTagsFromHighlights(highlights: Highlight[]) {
+    // extract all tags from all Highlights and
+    // construct an array with unique values
+
+    var tags: Tag[] = [];
+    this.sortHighlights(highlights).forEach((highlight: Highlight) =>
+      highlight.tags ? (tags = [...tags, ...highlight.tags]) : tags
+    );
+    return Array.from(new Set(tags));
+  }
+
   async writeLogToMarkdown(library: Library) {
     const vault = this.app.vault;
 
@@ -240,6 +251,8 @@ export default class ReadwiseMirror extends Plugin {
           .map((highlight: Highlight) => this.formatHighlight(highlight, book))
           .join('\n');
 
+        // get an array with all tags from highlights
+        const highlightTags = this.getTagsFromHighlights(filteredHighlights);
         const authors = author ? author.split(/and |,/) : [];
 
         let authorStr =
@@ -266,7 +279,9 @@ export default class ReadwiseMirror extends Plugin {
           last_highlight_at: last_highlight_at ? this.formatDate(last_highlight_at) : '',
           source_url: source_url,
           tags: this.formatTags(tags),
-          frontmatter_tags: this.formatTags(tags, true),
+          highlight_tags: this.formatTags(highlightTags),
+          quoted_tags: this.formatTags(tags, true),
+          quoted_highlight_tags: this.formatTags(highlightTags, true),
         };
 
         const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';

--- a/main.ts
+++ b/main.ts
@@ -87,12 +87,13 @@ export default class ReadwiseMirror extends Plugin {
   headerTemplate: Template;
   highlightTemplate: Template;
 
-  private formatTags(tags: Tag[], quote: boolean = false) {
+  private formatTags(tags: Tag[], nohash: boolean = false) {
     // use unique list of tags
-    const uniqueTags = [...new Set(tags.map((tag) => tag.name))];
+    const uniqueTags = [...new Set(tags.map((tag) => tag.name.replace(/\s/, '-')))];
 
-    if (quote) {
-      return uniqueTags.map((tag) => `"#${tag}"`).join(', ');
+    if (nohash) {
+      // don't return a hash in the tag name
+      return uniqueTags.map((tag) => `${tag}`).join(', ');
     } else {
       return uniqueTags.map((tag) => `#${tag}`).join(', ');
     }
@@ -283,8 +284,8 @@ export default class ReadwiseMirror extends Plugin {
           source_url: source_url,
           tags: this.formatTags(tags),
           highlight_tags: this.formatTags(highlightTags),
-          quoted_tags: this.formatTags(tags, true),
-          quoted_highlight_tags: this.formatTags(highlightTags, true),
+          tags_nohash: this.formatTags(tags, true),
+          hl_tags_nohash: this.formatTags(highlightTags, true),
         };
 
         const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';

--- a/main.ts
+++ b/main.ts
@@ -88,7 +88,11 @@ export default class ReadwiseMirror extends Plugin {
   highlightTemplate: Template;
 
   private formatTags(tags: Tag[], quote: boolean = false) {
-    return tags.map((tag) => `#${tag.name}`).join(', ');
+    if (quote) {
+      return tags.map((tag) => `"#${tag.name}"`).join(', ');
+    } else {
+      return tags.map((tag) => `#${tag.name}`).join(', ');
+    }
   }
 
   private formatHighlight(highlight: Highlight, book: Book) {

--- a/main.ts
+++ b/main.ts
@@ -291,7 +291,7 @@ export default class ReadwiseMirror extends Plugin {
           source_url: source_url,
           tags: this.formatTags(tags),
           highlight_tags: this.formatTags(highlightTags),
-          tags_nohash: this.formatTags(tags, true),
+          tags_nohash: this.formatTags(tags, true, "'"),
           hl_tags_nohash: this.formatTags(highlightTags, true, "'"),
         };
 

--- a/main.ts
+++ b/main.ts
@@ -87,7 +87,7 @@ export default class ReadwiseMirror extends Plugin {
   headerTemplate: Template;
   highlightTemplate: Template;
 
-  private formatTags(tags: Tag[]) {
+  private formatTags(tags: Tag[], quote: boolean = false) {
     return tags.map((tag) => `#${tag.name}`).join(', ');
   }
 
@@ -118,10 +118,8 @@ export default class ReadwiseMirror extends Plugin {
     // is_discard is not a field in the API response for (https://readwise.io/api/v2/highlights/), so we need to check if the highlight has the discard tag
     // is_discard field only showing under the /export API endpoint in the API docs: https://readwise.io/api_deets
 
-    return highlight.tags.some(tag => tag.name === 'discard')
-  }
-
-
+    return highlight.tags.some((tag) => tag.name === 'discard');
+  };
 
   private filterHighlights(highlights: Highlight[]) {
     return highlights.filter((highlight: Highlight) => {
@@ -129,7 +127,7 @@ export default class ReadwiseMirror extends Plugin {
 
       // Check if is discarded
       if (this.settings.highlightDiscard && this.highlightIsDiscarded(highlight)) {
-        console.log("Readwise: Found discarded highlight, removing", highlight)
+        console.log('Readwise: Found discarded highlight, removing', highlight);
         return false;
       }
 
@@ -149,15 +147,15 @@ export default class ReadwiseMirror extends Plugin {
         if (highlightA.location < highlightB.location) return -1;
         else if (highlightA.location > highlightB.location) return 1;
         return 0;
-      })
+      });
 
-      if (!this.settings.highlightSortOldestToNewest) sortedHighlights = sortedHighlights.reverse()
+      if (!this.settings.highlightSortOldestToNewest) sortedHighlights = sortedHighlights.reverse();
     } else {
-      sortedHighlights = this.settings.highlightSortOldestToNewest ? sortedHighlights.reverse() : sortedHighlights
+      sortedHighlights = this.settings.highlightSortOldestToNewest ? sortedHighlights.reverse() : sortedHighlights;
     }
 
-    return sortedHighlights
-  }
+    return sortedHighlights;
+  };
 
   async writeLogToMarkdown(library: Library) {
     const vault = this.app.vault;
@@ -234,7 +232,8 @@ export default class ReadwiseMirror extends Plugin {
       if (filteredHighlights.length === 0) {
         console.log(`Readwise: No highlights found for '${sanitizedTitle}'`);
       } else {
-        const formattedHighlights = this.sortHighlights(filteredHighlights).map((highlight: Highlight) => this.formatHighlight(highlight, book))
+        const formattedHighlights = this.sortHighlights(filteredHighlights)
+          .map((highlight: Highlight) => this.formatHighlight(highlight, book))
           .join('\n');
 
         const authors = author ? author.split(/and |,/) : [];
@@ -242,12 +241,12 @@ export default class ReadwiseMirror extends Plugin {
         let authorStr =
           authors[0] && authors?.length > 1
             ? authors
-              .filter((authorName: string) => authorName.trim() != '')
-              .map((authorName: string) => `[[${authorName.trim()}]]`)
-              .join(', ')
+                .filter((authorName: string) => authorName.trim() != '')
+                .map((authorName: string) => `[[${authorName.trim()}]]`)
+                .join(', ')
             : author
-              ? `[[${author}]]`
-              : ``;
+            ? `[[${author}]]`
+            : ``;
 
         const metadata = {
           id: id,
@@ -263,14 +262,16 @@ export default class ReadwiseMirror extends Plugin {
           last_highlight_at: last_highlight_at ? this.formatDate(last_highlight_at) : '',
           source_url: source_url,
           tags: this.formatTags(tags),
+          frontmatter_tags: this.formatTags(tags, true),
         };
 
         const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';
         const headerContents = this.headerTemplate.render(metadata);
         const contents = `${frontMatterContents}${headerContents}${formattedHighlights}`;
 
-        let path = `${this.settings.baseFolderName}/${category.charAt(0).toUpperCase() + category.slice(1)
-          }/${sanitizedTitle}.md`;
+        let path = `${this.settings.baseFolderName}/${
+          category.charAt(0).toUpperCase() + category.slice(1)
+        }/${sanitizedTitle}.md`;
 
         const abstractFile = vault.getAbstractFileByPath(path);
 
@@ -526,9 +527,7 @@ class ReadwiseMirrorSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Filter Discarded Highlights')
-      .setDesc(
-        'If enabled, do not display discarded highlights in the Readwise library.'
-      )
+      .setDesc('If enabled, do not display discarded highlights in the Readwise library.')
       .addToggle((toggle) =>
         toggle.setValue(this.plugin.settings.highlightDiscard).onChange(async (value) => {
           this.plugin.settings.highlightDiscard = value;

--- a/main.ts
+++ b/main.ts
@@ -89,15 +89,15 @@ export default class ReadwiseMirror extends Plugin {
   headerTemplate: Template;
   highlightTemplate: Template;
 
-  private formatTags(tags: Tag[], nohash: boolean = false) {
+  private formatTags(tags: Tag[], nohash: boolean = false, q: string = '') {
     // use unique list of tags
     const uniqueTags = [...new Set(tags.map((tag) => tag.name.replace(/\s/, '-')))];
 
     if (nohash) {
       // don't return a hash in the tag name
-      return uniqueTags.map((tag) => `'${tag}'`).join(', ');
+      return uniqueTags.map((tag) => `${q}${tag}${q}`).join(', ');
     } else {
-      return uniqueTags.map((tag) => `#${tag}`).join(', ');
+      return uniqueTags.map((tag) => `${q}#${tag}${q}`).join(', ');
     }
   }
 
@@ -292,7 +292,7 @@ export default class ReadwiseMirror extends Plugin {
           tags: this.formatTags(tags),
           highlight_tags: this.formatTags(highlightTags),
           tags_nohash: this.formatTags(tags, true),
-          hl_tags_nohash: this.formatTags(highlightTags, true),
+          hl_tags_nohash: this.formatTags(highlightTags, true, "'"),
         };
 
         const frontMatterContents = this.settings.frontMatter ? this.frontMatterTemplate.render(metadata) : '';

--- a/main.ts
+++ b/main.ts
@@ -88,10 +88,13 @@ export default class ReadwiseMirror extends Plugin {
   highlightTemplate: Template;
 
   private formatTags(tags: Tag[], quote: boolean = false) {
+    // use unique list of tags
+    const uniqueTags = [...new Set(tags.map((tag) => tag.name))];
+
     if (quote) {
-      return tags.map((tag) => `"#${tag.name}"`).join(', ');
+      return uniqueTags.map((tag) => `"#${tag}"`).join(', ');
     } else {
-      return tags.map((tag) => `#${tag.name}`).join(', ');
+      return uniqueTags.map((tag) => `#${tag}`).join(', ');
     }
   }
 
@@ -169,7 +172,7 @@ export default class ReadwiseMirror extends Plugin {
     this.sortHighlights(highlights).forEach((highlight: Highlight) =>
       highlight.tags ? (tags = [...tags, ...highlight.tags]) : tags
     );
-    return Array.from(new Set(tags));
+    return tags;
   }
 
   async writeLogToMarkdown(library: Library) {

--- a/main.ts
+++ b/main.ts
@@ -95,7 +95,7 @@ export default class ReadwiseMirror extends Plugin {
 
     if (nohash) {
       // don't return a hash in the tag name
-      return uniqueTags.map((tag) => `${tag}`).join(', ');
+      return uniqueTags.map((tag) => `'${tag}'`).join(', ');
     } else {
       return uniqueTags.map((tag) => `#${tag}`).join(', ');
     }

--- a/readwiseApi.ts
+++ b/readwiseApi.ts
@@ -109,10 +109,22 @@ export class ReadwiseApi {
 
       if (response.status === 429) {
         // Error handling for rate limit throttling
-        const rateLimitedDelayTime = parseInt(response.headers.get('Retry-After')) * 1000 + 1000;
+        // b/c of limitations with cross-origin requests, we don't have (easy) access to the header
+        // We must therefore extract the seconds from the statusText:
+        // "Request was throttled. Expected available in 39 seconds."
+
+        let rateLimitedDelayTime: number = 4000; // Base throttling, 20 requests per minute are the maximum allowable
+
+        if (data.detail) {
+          console.log(`Readwise: ${data.detail}`);
+          const rate = data.detail.match(/available\sin\s([0-9]+)\sseconds/);
+          if (rate) {
+            rateLimitedDelayTime = parseInt(rate[1]) * 1000 + 1000;
+          }
+        }
+
         console.warn(`Readwise: API Rate Limited, waiting to retry for ${rateLimitedDelayTime}`);
         this.notify.setStatusBarText(`Readwise: API Rate Limited, waiting ${rateLimitedDelayTime}`);
-
         await new Promise((_) => setTimeout(_, rateLimitedDelayTime));
         console.info('Readwise: Trying to fetch highlights again...');
         this.notify.setStatusBarText(`Readwise: Attempting to retry...`);
@@ -130,7 +142,8 @@ export class ReadwiseApi {
       }
     } while (data.next);
 
-    if (results.length > 0) console.info(`Readwise: Processed ${results.length} total ${contentType} results successfully`);
+    if (results.length > 0)
+      console.info(`Readwise: Processed ${results.length} total ${contentType} results successfully`);
     return results;
   }
 


### PR DESCRIPTION
I've implemented a few small changes that add two new features related to tags:

-  a roll-up of tags from highlights for frontmatter, and 
- quoted tags to be used in frontmatter tag arrays

With the two new fields, one can for example put all document tags or all tags from highlights into frontmatter as a tags array and can reduce clutter in notes as tags are preserved within a note.

Either set of tags is deduplicated (but only within the respective set, that is, document tags or highlight tags). If a tag is present in both tag sets, and both are added to frontmatter, the tag will be duplicate. 

Currently, I've created new metadata fields for this, as I think recreating the functionality in nunjucks is more complicated. 

