### PR TITLE
Quote filter for multi-line highlights in blockquotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,20 @@ Note: {{ note }}
 ---
 ```
 
+### Blockquote filter
+
+If you want to use blockquotes for text fields in your template, there's a handy `bq` filter that will put the quote character (`>`) in front of every new line. This is useful for both multi-line highlights as well as multi-line notes.
+
+With this filter, templates like the following become possible, without breaking the blockquote.
+
+```markdown+nunjucks
+> [!quote]
+> {{ text | bq }}{%- if category == 'books' %} ([{{ location }}]({{ location_url }})){%- endif %}{%- if color %} %% Color: {{ color }} %%{%- endif %} ^{{id}}{%- if note %}
+Note: {{ note }}
+{%- endif %}
+---
+```
+
 ### Limitations
 
 - The templating is based on the [`nunjucks`](https://mozilla.github.io/nunjucks/templating.html) templating library and thus shares its limitations;

--- a/main.ts
+++ b/main.ts
@@ -379,6 +379,12 @@ export default class ReadwiseMirror extends Plugin {
 
     // Setup templating
     this.env = new Environment(null, { autoescape: false } as ConfigureOptions);
+
+    // Add a nunjucks filter to convert newlines to "newlines + >" for quotes
+    this.env.addFilter('bq', function (str) {
+      return str.replace(/\r|\n|\r\n/g, '\r\n> ');
+    });
+
     this.frontMatterTemplate = new Template(this.settings.frontMatterTemplate, this.env, null, true);
     this.headerTemplate = new Template(this.settings.headerTemplate, this.env, null, true);
     this.highlightTemplate = new Template(this.settings.highlightTemplate, this.env, null, true);


### PR DESCRIPTION
- Multi-line text can be filtered with the `bq` filter
- The filter adds the `>` character after each line-break
- With this, you can get multi-line text blockquotes in your templates working correctly

# Example
The following highlight
```
Multi-line text in blockquotes

This is an example of a multi-line highlight with line-breaks. 
```
... with this template
```markdown+nunjucks
> [!quote]
> {{ text | bq }}
```
will turn into 
```markdown
> [!quote]
> Multi-line text in blockquotes
>
> This is an example of a multi-line highlight with line-breaks. 
```
