### PR TITLE
feat: :sparkles: hot-reload settings after sync

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -403,6 +403,14 @@ export default class ReadwiseMirror extends Plugin {
     return spacetime.now().since(spacetime(this.settings.lastUpdated)).rounded;
   }
 
+  // Reload settings after external change (e.g. after sync)
+  async onExternalSettingsChange() {
+    console.info(`Reloading settings due to external change`)
+    await this.loadSettings();
+    if (this.settings.lastUpdated)
+        this.notify.setStatusBarText(`Readwise: Updated ${this.lastUpdatedHumanReadableFormat()} elsewhere`);
+  }
+  
   async onload() {
     await this.loadSettings();
 


### PR DESCRIPTION
readwise-mirror is currently unaware if an Obsidian sync is implemented, notably resulting in ambiguities regarding its own sync status if a Readwise sync happened elsewhere later (or earlier, but unsynced) than locally. 

This proposal implements "onExternalSettingsChange" to reload the settings and update the Status according to the last successful external sync. 

I am not entirely sure this is strictly necessary. But generally speaking would consider it good practice to reload the settings if changed elsewhere and pushed through any kind of Obsidian sync. This keeps the state of the Vault and of the Readwise sync in sync.

Please note:

- Unless a Readwise sync happened in at least two locations with at least one location being offline for Obsidian sync, the latest Readwise sync date should always prevail
- In case a local Readwise sync happened while being offline (or before a remote Readwise sync was pushed through Obsidian sync), the earlier sync might prevail in some circumstances 
- At least when using the official Obsidian sync, this is very unlikely as both Obsidian and Readwise sync require the Obsidian instance to be online to work

For clarity: 
- Obsidian sync: Settings and content synced between two or more Obsidian instances
- Readwise sync: The works of this plugin, i.e. syncing Readwise highlights to one specific Obsidian instance