### PR TITLE
refactor: :recycle: use process() method to write new content

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,4 +1,4 @@
-import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import { App, Plugin, PluginSettingTab, Setting, TFile } from 'obsidian';
 import Notify from 'notify';
 import spacetime from 'spacetime';
 import { Environment, Template, ConfigureOptions } from 'nunjucks';
@@ -310,11 +310,11 @@ export default class ReadwiseMirror extends Plugin {
         let path = `${this.settings.baseFolderName}/${category.charAt(0).toUpperCase() + category.slice(1)
           }/${sanitizedTitle}.md`;
 
-        const abstractFile = vault.getFileByPath(path);
+        const abstractFile = vault.getAbstractFileByPath(path);
 
         // Overwrite existing file with remote changes, or
         // Create new file if not existing
-        if (abstractFile) {
+        if (abstractFile && abstractFile instanceof TFile) {
           // File exists
           try {
             await vault.process(abstractFile, function(data) {

--- a/main.ts
+++ b/main.ts
@@ -310,18 +310,25 @@ export default class ReadwiseMirror extends Plugin {
         let path = `${this.settings.baseFolderName}/${category.charAt(0).toUpperCase() + category.slice(1)
           }/${sanitizedTitle}.md`;
 
-        const abstractFile = vault.getAbstractFileByPath(path);
+        const abstractFile = vault.getFileByPath(path);
 
-        // Delete old instance of file
+        // Overwrite existing file with remote changes, or
+        // Create new file if not existing
         if (abstractFile) {
+          // File exists
           try {
-            await vault.delete(abstractFile);
+            await vault.process(abstractFile, function(data) {
+              // Simply return new contents to overwrite file
+              return contents;
+            });
           } catch (err) {
-            console.error(`Readwise: Attempted to delete file ${path} but no file was found`, err);
+            console.error(`Readwise: Attempt to overwrite file ${path} failed`, err);
           }
+        } else {
+          // File does not exist
+          vault.create(path, contents);
         }
-
-        vault.create(path, contents);
+        
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@rollup/plugin-node-resolve": "^11.2.1",
     "@rollup/plugin-typescript": "^8.2.1",
     "@types/node": "^14.14.37",
-    "obsidian": "^0.12.0",
+    "obsidian": "^1.1.1",
     "rollup": "^2.32.1",
     "tslib": "^2.2.0",
     "typescript": "^4.2.4"


### PR DESCRIPTION
Use the [`Vault.process()`](https://docs.obsidian.md/Reference/TypeScript+API/Vault/process) method to atomically read, modify, and save the contents of existing notes when updating from Readwise, instead of completely deleting and recreating the files. Should improve overall compatibility with other plugins, i.e. in the case of parallel edits. 

The switch from `getAbstractFileByPath()` to `getFileByPath()` should simplify things without compromising functionalty.