### PR TITLE
feat: :zap: implement "fetch-retry"

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@types/nunjucks": "^3.2.0",
+    "fetch-retry": "^6.0.0",
     "nunjucks": "^3.2.3",
     "spacetime": "^6.16.0"
   }

--- a/readwiseApi.ts
+++ b/readwiseApi.ts
@@ -1,5 +1,7 @@
 import Notify from 'notify';
+import fetchBuilder from 'fetch-retry';
 
+const fetch = fetchBuilder(global.fetch, { retries: 3, retryDelay: 1000 });
 const API_ENDPOINT = 'https://readwise.io/api/v2';
 const API_PAGE_SIZE = 1000; // number of results per page, default 100 / max 1000
 
@@ -130,7 +132,8 @@ export class ReadwiseApi {
       }
     } while (data.next);
 
-    if (results.length > 0) console.info(`Readwise: Processed ${results.length} total ${contentType} results successfully`);
+    if (results.length > 0)
+      console.info(`Readwise: Processed ${results.length} total ${contentType} results successfully`);
     return results;
   }
 


### PR DESCRIPTION
This is a small quality of life improvement to the current version of the plugin: it will make downloading the library more robust by using "fetch-retry", currently set at maximum three retries. This should help bridge small network hiccups (e.g. related to changing network  or similar situations).

