### PR TITLE
fix: remove misleading "Previous sync not detected" toast wording

### DIFF
--- a/src/services/controller.ts
+++ b/src/services/controller.ts
@@ -69,7 +69,7 @@ export class Controller {
       let library: Library;
       if (!this.ctx.settings.lastUpdated) {
         if (this.ctx.settings.syncNotifications)
-          this.ctx.notice('Readwise: Previous sync not detected...\nDownloading full Readwise library');
+          this.ctx.notice('Readwise: Downloading full Readwise library');
         if (!(await Controller.validateAPIInstance())) {
           this.ctx.notice('Readwise: Network connection and valid API Token required');
           return;


### PR DESCRIPTION
## Summary
- The full-download toast says "Previous sync not detected" even when `lastUpdated` was deliberately cleared by `download()` or `deleteLibrary()`
- Replace with neutral wording ("Downloading full Readwise library") that is accurate for first sync, forced re-download, and post-delete resync

## Context
`download()` (line 665) and `deleteLibrary()` (line 673) both set `lastUpdated = null` before the next `sync()` call. The `sync()` method (line 598) then treats a missing timestamp as a first-ever sync and displays "Previous sync not detected..." — which is misleading when the user intentionally triggered a re-download.

## Test plan
- [ ] Run "Download entire Readwise library (force)" command — toast should say "Downloading full Readwise library"
- [ ] Delete library and re-sync — same neutral message
- [ ] Fresh install with no prior sync — same neutral message (still accurate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the Readwise sync notification message to a single-line format for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->