### PR TITLE
Prevent single article parsing error from being a fatal error stopping sync or update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "readwise-mirror",
-            "version": "2.4.0-beta.6",
+            "version": "2.4.0-beta.7",
             "license": "MIT",
             "dependencies": {
                 "@sindresorhus/slugify": "^2.2.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -467,17 +467,25 @@ export default class ReadwiseMirror extends Plugin {
       // Atomize only when enabled and when trackFiles is enabled as well
       const atomizer = new Atomizer();
       if (shouldAtomize) {
-        // FIXME: Handle basename changes of the parent file: we need to update all atomized files as well, or ensure we catch a differing basename vs. primary file
-        const { contents, atoms } = atomizer.atomize(_contents, { basename, doc, book });
-        this.logger.debug(`Atomized ${atoms?.length} highlights for '${title}' (${source_url})`);
-        readwiseFile.contents = contents;
-        readwiseFile.atoms = atoms;
+        try {
+          const { contents, atoms } = atomizer.atomize(_contents, { basename, doc, book });
+          this.logger.debug(`Atomized ${atoms?.length} highlights for '${title}' (${source_url})`);
+          readwiseFile.contents = contents;
+          readwiseFile.atoms = atoms;
+        } catch (err) {
+          this.logger.error(`Failed to atomize '${title}' (${unique_url}): ${err}`);
+          readwiseFile.contents = _contents; // fall back to raw contents
+        }
       } else {
-        // Set atomizer to composite mode and remove frontmatter blocks
         atomizer.setCompositeEnvironment();
-        const { contents } = atomizer.atomize(_contents, { basename, doc, book });
-        readwiseFile.contents = contents;
-      }
+        try {
+          const { contents } = atomizer.atomize(_contents, { basename, doc, book });
+          readwiseFile.contents = contents;
+        } catch (err) {
+          this.logger.error(`Failed to process composite '${title}' (${unique_url}): ${err}`);
+          readwiseFile.contents = _contents; // fall back to raw contents
+        }
+      }      
       readwiseFiles.push(readwiseFile);
     }
     return readwiseFiles;

--- a/src/main.ts
+++ b/src/main.ts
@@ -477,8 +477,8 @@ export default class ReadwiseMirror extends Plugin {
           readwiseFile.contents = _contents; // fall back to raw contents
         }
       } else {
-        atomizer.setCompositeEnvironment();
         try {
+          atomizer.setCompositeEnvironment();
           const { contents } = atomizer.atomize(_contents, { basename, doc, book });
           readwiseFile.contents = contents;
         } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,7 +344,7 @@ export default class ReadwiseMirror extends Plugin {
       bookCurrent += 1;
       const book: Export = library.books[bookId];
 
-      const { title, category, highlights, source_url } = book;
+      const { title, category, highlights, source_url, unique_url } = book;
 
       // Sanitize title, replace colon with substitute from settings
       const basename = this.getFileNameFromDoc(book);


### PR DESCRIPTION
Added try/catch around atomizer calls. Instead of a single error aborting all other sync or updates, it now logs a detailed error with the specific file that caused the problem and returns the untemplated content rather than nothing. Processing of other files continues.

Fixes impact of https://github.com/jsonMartin/readwise-mirror/issues/92 but not the root cause.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting with more descriptive error messages during processing failures
  * Implemented graceful fallback mechanism to prevent processing interruptions when atomization fails
  * Improved system reliability by continuing processing with alternative data when optimization steps encounter errors
  * Better handling of edge cases in library processing workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->