### PR TITLE
fix: :bug: refactor loadAndApplySettings for settings mutation

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -160,9 +160,12 @@ export default class ReadwiseMirror extends Plugin {
    */
   async loadAndApplySettings() {
     const loaded = (await this.loadData()) as Partial<PluginSettings> | null;
-    this.settings = { ...DEFAULT_SETTINGS, ...(loaded ?? {}) };
+    
+    // Mutate the existing object instead of creating a new reference
+    // Order matters: defaults first, then loaded values override them
+    Object.assign(this.settings, DEFAULT_SETTINGS, loaded ?? {});
+    
     if (this.lock.isAcquired('readwise-mirror:loaded')) {
-      // Only apply settings if plugin is loaded, and create settings tab at the same time
       await this.applySettings();
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,9 +78,7 @@ export default class ReadwiseMirror extends Plugin {
       // exposed methods
       notice: (message: string, duration?: number) => this.notify.notice(message, duration),
       setStatusBarText: (message: string) => this.notify.setStatusBarText(message),
-      saveAndApplySettings: () => {
-        this.settings = ctx.settings;
-        return this.saveAndApplySettings();
+      saveAndApplySettings: () => this.saveAndApplySettings(),
       },
     };
     return ctx;

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,6 @@ export default class ReadwiseMirror extends Plugin {
       notice: (message: string, duration?: number) => this.notify.notice(message, duration),
       setStatusBarText: (message: string) => this.notify.setStatusBarText(message),
       saveAndApplySettings: () => this.saveAndApplySettings(),
-      },
     };
     return ctx;
   }
@@ -158,11 +157,11 @@ export default class ReadwiseMirror extends Plugin {
    */
   async loadAndApplySettings() {
     const loaded = (await this.loadData()) as Partial<PluginSettings> | null;
-    
+
     // Mutate the existing object instead of creating a new reference
     // Order matters: defaults first, then loaded values override them
     Object.assign(this.settings, DEFAULT_SETTINGS, loaded ?? {});
-    
+
     if (this.lock.isAcquired('readwise-mirror:loaded')) {
       await this.applySettings();
     }


### PR DESCRIPTION
Refactor settings loading to mutate existing object instead of creating a new reference. Catches a regression with externally changed settings used by some of the Managers (e.g. frontmatter template).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings updates to ensure changes are saved and applied consistently.
  * Preserved existing settings references during loading, improving reliability for features that depend on current configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->