### PR TITLE
fix: :bug: refactor settings loading and saving methods

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -160,9 +160,12 @@ export default class ReadwiseMirror extends Plugin {
    */
   async loadAndApplySettings() {
     const loaded = (await this.loadData()) as Partial<PluginSettings> | null;
-    this.settings = { ...DEFAULT_SETTINGS, ...(loaded ?? {}) };
+    
+    // Mutate the existing object instead of creating a new reference
+    // Order matters: defaults first, then loaded values override them
+    Object.assign(this.settings, DEFAULT_SETTINGS, loaded ?? {});
+    
     if (this.lock.isAcquired('readwise-mirror:loaded')) {
-      // Only apply settings if plugin is loaded, and create settings tab at the same time
       await this.applySettings();
     }
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -78,9 +78,7 @@ export default class ReadwiseMirror extends Plugin {
       // exposed methods
       notice: (message: string, duration?: number) => this.notify.notice(message, duration),
       setStatusBarText: (message: string) => this.notify.setStatusBarText(message),
-      saveAndApplySettings: () => {
-        this.settings = ctx.settings;
-        return this.saveAndApplySettings();
+      saveAndApplySettings: () => this.saveAndApplySettings(),
       },
     };
     return ctx;

--- a/src/main.ts
+++ b/src/main.ts
@@ -79,7 +79,6 @@ export default class ReadwiseMirror extends Plugin {
       notice: (message: string, duration?: number) => this.notify.notice(message, duration),
       setStatusBarText: (message: string) => this.notify.setStatusBarText(message),
       saveAndApplySettings: () => this.saveAndApplySettings(),
-      },
     };
     return ctx;
   }
@@ -158,11 +157,11 @@ export default class ReadwiseMirror extends Plugin {
    */
   async loadAndApplySettings() {
     const loaded = (await this.loadData()) as Partial<PluginSettings> | null;
-    
+
     // Mutate the existing object instead of creating a new reference
     // Order matters: defaults first, then loaded values override them
     Object.assign(this.settings, DEFAULT_SETTINGS, loaded ?? {});
-    
+
     if (this.lock.isAcquired('readwise-mirror:loaded')) {
       await this.applySettings();
     }


### PR DESCRIPTION
This pull request makes a couple of targeted improvements to the `ReadwiseMirror` plugin's settings handling. The main changes involve how settings are saved and loaded, with a focus on preserving object references and simplifying method calls.

Settings management improvements:

* The `loadAndApplySettings` method now uses `Object.assign` to mutate the existing `this.settings` object instead of creating a new object reference, ensuring that settings updates are reflected wherever the reference is used.
* The exposed `saveAndApplySettings` method is simplified to directly call the class method, removing unnecessary assignment to `this.settings` and preventing potential reference issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings updates so changes are applied consistently throughout the plugin.
  * Preserved settings state references when loading and applying saved configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->